### PR TITLE
Set up Python Semantic Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Python Semantic Release
+      uses: relekang/python-semantic-release@v6.3.1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[semantic_release]
+version_variable = setup.py:__version__
+commit_subject = version {version}

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,9 @@ from os import path
 from setuptools import setup
 
 
+__version__ = "2.0.0"
+
+
 here = path.abspath(path.dirname(__file__))
 
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
@@ -9,7 +12,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="minegen",
-    version="2.0.0",
+    version=__version__,
     packages=["minegen"],
     package_dir={"minegen": "minegen"},
     description="Minecraft achievement generator",


### PR DESCRIPTION
Set up Python Semantic Release on GitHub actions, to automatically publish to PyPI when needed.

---
**Some additional set-up is required from @adlgrbz:**

- Log in / create an account on [PyPI](https://pypi.org/).
- Go to [this page](https://pypi.org/manage/account/token/) and create a new API token. It'll probably need the "entire account" scope since the project hasn't been uploaded before.
- Copy the new token (beginning with `pypi-`).
- Finally, go [here](https://github.com/adlgrbz/minegen/settings/secrets) and create a new secret named `PYPI_TOKEN`, and paste the token as the value.
---

In order to trigger uploads, commit messages need to follow the [Angular commit style](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#commits). Basically:

- Commit title begins with one of these words, followed by a colon: (there are others, but these are the main options.)
  - **feat**: A new feature
  - **fix**: A bug fix
  - **perf**: Improves performance
  - **docs**: Changes to documentation such as `README.md`
  - **style**: Changes that do not affect the meaning of the code (formatting, etc)
  - **refactor**: A code change that neither fixes a bug nor adds a feature
- Include `BREAKING CHANGE:` before the description to create a new major (e.g. `v2.0.0`) version.

Examples:

```
feat: create a cool new feature
```

```
fix: fix bug X
```

```
feat: create feature Y

BREAKING CHANGE: Feature Z has been removed.
```

Closes #3 